### PR TITLE
Fix getting full paths cross platform

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ dependencies:
     - ./script/bootstrap
   cache_directories:
     - vendor
+  pre:
+    - sudo apt-get update && sudo apt-get install --no-install-recommends realpath
 
 test:
   override:

--- a/features/biobox.feature
+++ b/features/biobox.feature
@@ -127,8 +127,8 @@ Feature: A CLI to run biobox-compatible Docker containers
     And the file "contigs.fa" should not be empty
 
     Examples:
-      | assembler        | args            | input                      | output                    |
-      | bioboxes/velvet  |                 | reads.fq.gz                | contigs.fa                |
-      | bioboxes/velvet  |                 | $(readlink -f reads.fq.gz)    | contigs.fa                |
-      | bioboxes/velvet  |                 | reads.fq.gz                | $(readlink -f contigs.fa)    |
-      | bioboxes/megahit | --task=no-mercy | reads.fq.gz                | contigs.fa                |
+      | assembler        | args            | input                   | output                   |
+      | bioboxes/velvet  |                 | reads.fq.gz             | contigs.fa               |
+      | bioboxes/velvet  |                 | $(realpath reads.fq.gz) | contigs.fa               |
+      | bioboxes/velvet  |                 | reads.fq.gz             | $(realpath .)/contigs.fa |
+      | bioboxes/megahit | --task=no-mercy | reads.fq.gz             | contigs.fa               |


### PR DESCRIPTION
Previously `readlink -f` was used, however this does not work on OSX because a different version is installed. The command `realpath` is available on both Linux and OSX and so can be used cross-platform.
