### PR TITLE
feature remove container

### DIFF
--- a/biobox_cli/biobox_type/short_read_assembler.py
+++ b/biobox_cli/biobox_type/short_read_assembler.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    biobox run short_read_assembler <image> --input=FILE --output=FILE [--task=TASK]
+    biobox run short_read_assembler <image> [--no-rm-container] --input=FILE --output=FILE [--task=TASK]
 
 Options:
   -h, --help              Show this screen.
@@ -46,6 +46,15 @@ def run(argv):
         ctn.biobox_file_mount_string(fle.create_biobox_directory(biobox_yaml)),
         ctn.output_directory_mount_string(host_dst_dir)]
 
-    ctn.run(ctn.create(image, task, mount_strings))
+    ctnr = ctn.create(image, task, mount_strings)
+    ctn.run(ctnr)
     biobox_output = fle.parse(host_dst_dir)
     copy_contigs_file(host_dst_dir, biobox_output, contig_file)
+    return ctnr
+
+def remove(container):
+    """
+    Removes a container
+    Note this method is not tested due to limitations of circle ci
+    """
+    ctn.remove(container)

--- a/biobox_cli/command/run.py
+++ b/biobox_cli/command/run.py
@@ -8,7 +8,6 @@ Options:
   -h, --help     Show this screen.
 
 Available Biobox types:
-
   short_read_assembler  Assemble short reads into contigs
 """
 
@@ -16,4 +15,7 @@ import biobox_cli.util as util
 
 def run(argv):
     opts = util.parse_docopt(__doc__, argv, True)
-    util.select_module("biobox_type", opts["<biobox_type>"]).run(argv)
+    module = util.select_module("biobox_type", opts["<biobox_type>"])
+    ctnr = module.run(argv)
+    if not '--no-rm-container' in argv:
+        module.remove(ctnr)

--- a/biobox_cli/container.py
+++ b/biobox_cli/container.py
@@ -46,3 +46,10 @@ def create(image, command, mounts = []):
 def run(container):
     client().start(container)
     client().wait(container)
+
+def remove(container):
+    """
+    Removal of a container
+    NOTE: This method is not tested due to circle ci limitations
+    """
+    client().remove_container(container, v=True)

--- a/features/biobox.feature
+++ b/features/biobox.feature
@@ -116,6 +116,7 @@ Feature: A CLI to run biobox-compatible Docker containers
         run \
         short_read_assembler \
         <assembler> \
+        --no-rm-container \
         --input=<input> \
         --output=<output> \
         <args>


### PR DESCRIPTION
see #40 

In my opinion would be the best position for a '--no-rm-container' parameter in the following position:

```
biobox run --no-rm-container short_read_assembler bioboxes/velvet  --param1 .... 
```

However I could not implement it with docopt. Just the following version works with docopt is 

```
biobox run short_read_assembler bioboxes/velvet --no-rm-container --param1 --param2 ...
```

Michael please merge this if you agree on this "temporary" solution
