### PR TITLE
Python 3/2 compatibility

### DIFF
--- a/biobox_cli/behave_interface.py
+++ b/biobox_cli/behave_interface.py
@@ -60,7 +60,10 @@ def is_failed(behave_data):
     return "failed" in map(lambda i: i['status'], behave_data)
 
 def get_scenarios(behave_data):
-    return reduce(lambda acc, x: acc + x['elements'], behave_data, [])
+    acc = []
+    for item in behave_data:
+        acc += item['elements']
+    return acc
 
 def scenario_name(scenario):
     return scenario["name"]
@@ -69,12 +72,12 @@ def scenario_status(scenario):
     """
     Returns the status of the last step in a scenario
     """
-    status = fn.thread([
+    status = list(fn.thread([
         scenario['steps'],
         F(map, fn.get("result")),
         F(filter, fn.is_not_none),
         F(map, fn.get("status")),
-        ])
+        ]))
     if fn.is_empty(status):
         return "not run"
     else:
@@ -87,12 +90,12 @@ def get_failing_scenarios(behave_data):
     """
     Returns all failing scenarios from a behave dictionary
     """
-    return filter(is_failed_scenario, get_scenarios(behave_data))
+    return list(filter(is_failed_scenario, get_scenarios(behave_data)))
 
 def get_scenarios_and_statuses(behave_data):
     """
     Returns a list of scenarios and their status
     """
-    return fn.thread([
+    return list(fn.thread([
         get_scenarios(behave_data),
-        F(map, lambda x: [scenario_name(x), scenario_status(x)])])
+        F(map, lambda x: [scenario_name(x), scenario_status(x)])]))

--- a/biobox_cli/biobox_file.py
+++ b/biobox_cli/biobox_file.py
@@ -19,7 +19,7 @@ def reference_argument(ref):
     return {"fasta_dir": ref}
 
 def files_values(identifier, args):
-    values = map(lambda (i, (p_c, t)) : entry(identifier + "_" + str(i), p_c, t), enumerate(args))
+    values = [entry(identifier + "_" + str(i), p_c, t) for (i, (p_c, t)) in enumerate(args)]
     return {identifier : values}
 
 def entry(id_, value, type_):

--- a/biobox_cli/command/verify.py
+++ b/biobox_cli/command/verify.py
@@ -14,6 +14,7 @@ Available Biobox types:
 
   short_read_assembler  Assemble short reads into contigs
 """
+from __future__ import print_function
 
 import biobox_cli.util.misc        as util
 import biobox_cli.util.error       as error
@@ -27,13 +28,16 @@ import sys
 from fn    import F, _
 from fn.op import flip
 
+def name_and_status(x, y):
+    return format_scenario_name(x), format_scenario_status(y)
+
 def format_scenario_name(name):
     return fn.thread([
-        string.replace(name, "Should ", ""),
+        str.replace(name, "Should ", ""),
         lambda x: x[0].upper() + x[1:],
-        F(flip(string.split), '--'),
+        F(flip(str.split), '--'),
         fn.first,
-        string.strip])
+        str.strip])
 
 def format_scenario_status(status):
     formats = {
@@ -66,19 +70,20 @@ def run(argv):
             sys.stdout = open(log, "w+")
         statuses = fn.thread([
             behave.get_scenarios_and_statuses(results),
-            F(map, lambda (x, y): (format_scenario_name(x), format_scenario_status(y)))])
+            F(map, name_and_status)])
         longest_name = fn.thread([
             statuses,
             F(map, fn.first),
             F(map, len),
             max])
+        def justify(x, y): return string.ljust(x, longest_name, ' '), y
         output = fn.thread([
             statuses,
-            F(map, lambda (x, y): (string.ljust(x, longest_name, ' '), y)),
+            F(map, justify),
             F(map, F(flip(string.join), "   ")),
             fn.unique,
             F(flip(string.join), "\n")])
-        print output
+        print(output)
     elif behave.is_failed(results):
         if log:
             sys.stderr = open(log, "w+")

--- a/biobox_cli/container.py
+++ b/biobox_cli/container.py
@@ -1,5 +1,9 @@
 import logging, os
 logging.getLogger("requests").setLevel(logging.WARNING)
+try:
+    from functools import reduce
+except ImportError:
+    pass
 
 import docker
 import docker.utils
@@ -48,7 +52,7 @@ def create(image, command, volumes = []):
     return client().create_container(
             image,
             command,
-            volumes     = map(lambda x: x.split(":")[0], volumes),
+            volumes     = list(map(lambda x: x.split(":")[0], volumes)),
             host_config = docker.utils.create_host_config(binds=volumes))
 
 def create_tty(image, tty, volumes = []):

--- a/biobox_cli/main.py
+++ b/biobox_cli/main.py
@@ -17,7 +17,7 @@ Biobox types:
     short_read_assembler    Assemble short reads into contigs
 """
 
-import sys, string
+import sys
 
 from fn import F
 
@@ -35,5 +35,5 @@ def input_args():
     """
     return fn.thread([
         sys.argv[1:],
-        F(map, string.strip),
+        F(map, str.strip),
         F(filter, fn.is_not_empty)])

--- a/biobox_cli/util/functional.py
+++ b/biobox_cli/util/functional.py
@@ -1,3 +1,8 @@
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
 def get(key):
     """
     Function that returns a function that will look up the given key in a
@@ -24,7 +29,7 @@ def is_not_empty(x):
     return not is_empty(x)
 
 def is_empty(x):
-    return len(x) == 0
+    return len(list(x)) == 0
 
 def first(x):
     return x[0]


### PR DESCRIPTION
Most of the issues are related to `map` and `filter` returning iterables (instead of lists, as in Py2), the removal of `reduce` and [tuples not being expanded](https://www.python.org/dev/peps/pep-3113/) on `lambda`s anymore.

I'll still do some review to avoid calling `list` in some places, but submitting to let @michaelbarton figure out how to run py3 on Circle =]
